### PR TITLE
Change to INameable to grab custom name or block name, and highlight fix

### DIFF
--- a/src/main/java/mcjty/rftoolsstorage/modules/scanner/client/GuiStorageScanner.java
+++ b/src/main/java/mcjty/rftoolsstorage/modules/scanner/client/GuiStorageScanner.java
@@ -333,8 +333,8 @@ public class GuiStorageScanner extends GenericGuiContainer<StorageScannerTileEnt
         }
         PacketReturnInventoryInfo.InventoryInfo c = fromServer_inventories.get(index - 1);
         if (c != null) {
-            // @todo 1.14
-//            RFTools.instance.clientInfo.hilightBlock(c.getPos(), System.currentTimeMillis() + 1000 * StorageScannerConfiguration.hilightTime.get());
+
+            RFToolsBase.instance.clientInfo.hilightBlock(c.getPos(), System.currentTimeMillis() + 1000 * StorageScannerConfiguration.hilightTime.get());
             Logging.message(minecraft.player, "The inventory is now highlighted");
             minecraft.player.closeContainer();
         }

--- a/src/main/java/mcjty/rftoolsstorage/modules/scanner/network/PacketGetInventoryInfo.java
+++ b/src/main/java/mcjty/rftoolsstorage/modules/scanner/network/PacketGetInventoryInfo.java
@@ -14,6 +14,7 @@ import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.INameable;
 import net.minecraft.util.RegistryKey;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -111,18 +112,11 @@ public class PacketGetInventoryInfo {
         } else {
             displayName = Tools.getReadableName(world, pos);
             TileEntity storageTe = world.getBlockEntity(pos);
-            if (storageTe instanceof ModularStorageTileEntity) {
-                ModularStorageTileEntity storageTileEntity = (ModularStorageTileEntity) storageTe;
-                String finalDisplayName = displayName;
-                displayName = storageTileEntity.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).map(h -> {
-                    ItemStack storageModule = h.getStackInSlot(ModularStorageContainer.SLOT_STORAGE_MODULE);
-                    if (!storageModule.isEmpty()) {
-                        if (storageModule.hasTag() && storageModule.getTag().contains("display")) {
-                            return storageModule.getHoverName().getString() /* was getFormattedText() */;
-                        }
-                    }
-                    return finalDisplayName;
-                }).orElse(displayName);
+            
+            if(storageTe instanceof INameable)
+            {
+                INameable namedBlock = (INameable)storageTe;
+                displayName = namedBlock.getDisplayName().getString();
             }
         }
         return new PacketReturnInventoryInfo.InventoryInfo(pos, displayName, te.isRoutable(pos), block);


### PR DESCRIPTION
To display custom names instead of default block names, Changed method of returning displayName to lookup iNameable and use getDisplayName over getHoverName.

I have removed what appears to be some method of returning names on Modular storages as it does not work,  Also modular storages do not seem to retain their NBT when being placed so naming them in an anvil does not work, unfortunately I have not had a chance to look at why that might be,

Also I have included a fix to update the blockHighlight on double click